### PR TITLE
Add view controller containment to ViewController

### DIFF
--- a/SquareWorkflowDemo/ViewController.swift
+++ b/SquareWorkflowDemo/ViewController.swift
@@ -40,10 +40,12 @@ class ViewController: UIViewController {
         let container = ContainerViewController(
             workflow: RootWorkflow()
         )
-                
+
+        addChild(container)
         let containerView = container.view!
         self.view.addSubview(containerView)
         containerView.translatesAutoresizingMaskIntoConstraints = false
+        container.didMove(toParent: self)
 
         NSLayoutConstraint.activate([
             containerView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),


### PR DESCRIPTION
Without the view controller containment, UI events aren’t correctly delivered, resulting in the UITextField delegate methods in `HelloViewController` never being called.